### PR TITLE
fix(edge/sql): import boot (xlsx dynamic) + RunTask override (pg_net body) + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,16 @@
   - Auto-assign des sources restreint à `is_global = true` et `access_level = 'standard'`.
 
 
+## 2025-09-17
+
+- Edge Functions
+  - `import-csv-user` v15: correction BOOT_ERROR en supprimant un doublon de fonction et en chargeant `xlsx` dynamiquement via `await import(...)` (évite un échec de démarrage si le module n'est pas résolu au boot).
+  - `chunked-upload`: délégation inchangée, mais renverra désormais l'erreur applicative de l'Edge import si présente.
+
+- Supabase SQL (pg_net / Vault)
+  - `run_algolia_data_task_override`: corrige l'utilisation de `pg_net.http_post` en lisant `body` (au lieu de `content`) et journalise la réponse `http` + `body` en `audit_logs`. Conserve fallback des credentials via Vault (`ALGOLIA_APP_ID`/`ALGOLIA_ADMIN_KEY`).
+
+- Import utilisateur (robustesse)
+  - Respect strict du champ `Source` tel que fourni dans le CSV (suppression du trigger de forçage et projection mise à jour antérieurement).
+  - Favoris automatiques: retries jusqu'à disponibilité des `object_id` dans `user_batch_algolia` via RPC `add_import_overlays_to_favorites`.
+

--- a/docs/migration/fix-run_algolia_override-2025-09-17.md
+++ b/docs/migration/fix-run_algolia_override-2025-09-17.md
@@ -1,0 +1,17 @@
+### Fix: run_algolia_data_task_override (pg_net)
+
+- Problème: la fonction SQL `public.run_algolia_data_task_override` utilisait `content` (ancienne signature http) alors que `pg_net.http_post` renvoie un objet avec `body`. Résultat: erreur "column \"content\" does not exist" et 502 dans le flux d'import.
+
+- Correctif appliqué le 2025-09-17:
+  - Remplacement de `SELECT content::jsonb ... FROM net.http_post(...)` par un `SELECT to_jsonb(r) ...` pour capturer la réponse complète, puis parsing de `v_http->>'body'` en JSON.
+  - Audit: insertion dans `audit_logs` de la réponse complète (`http`) et du `body` parsé.
+  - Conservation du fallback de credentials via Vault (`ALGOLIA_APP_ID`/`ALGOLIA_ADMIN_KEY`) si les GUC ne sont pas définies.
+
+- Impact:
+  - Plus d'erreur 502 sur `chunked-upload`/`import-csv-user` liée au RunTask.
+  - RunTask Algolia fonctionne pour l'override ciblé `user_batch_algolia`.
+
+- Déploiement:
+  - Migration exécutée via MCP Supabase (fonction remplacée en place).
+
+

--- a/supabase/functions/import-csv-user/index.ts
+++ b/supabase/functions/import-csv-user/index.ts
@@ -4,7 +4,6 @@
 // refresh projection par source, sync Algolia incrémentale (updateObject)
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import * as XLSX from 'https://esm.sh/xlsx@0.18.5'
 // Import du parser CSV robuste
 import { RobustCsvParser } from './csv-parser.ts'
 
@@ -18,18 +17,6 @@ const corsHeaders = {
 
 function json(status: number, body: unknown) {
   return new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
-}
-
-function formatError(err: any): string {
-  try {
-    if (!err) return 'unknown_error'
-    if (typeof err === 'string') return err
-    const message = (err as any).message || (err as any).error_description || (err as any).msg || (err as any).code || 'error'
-    const details = (err as any).details || (err as any).hint || (err as any).explanation || ''
-    return details ? `${message} | ${details}` : String(message)
-  } catch {
-    return String(err)
-  }
 }
 
 function formatError(err: any): string {
@@ -88,6 +75,8 @@ async function readXlsxContent(url: string): Promise<string> {
   const res = await fetch(url);
   if (!res.ok) throw new Error('Cannot fetch XLSX from storage');
   const arrayBuffer = await res.arrayBuffer();
+  // Chargement dynamique pour éviter un échec de boot si le module n'est pas disponible
+  const XLSX = await import('https://esm.sh/xlsx@0.18.5');
   const workbook = XLSX.read(arrayBuffer, { type: 'array' });
   const firstSheetName = workbook.SheetNames[0];
   const worksheet = workbook.Sheets[firstSheetName];


### PR DESCRIPTION
### Contexte
- Erreurs 503 (BOOT_ERROR) sur `import-csv-user` et 502 `delegate_failed` lors des imports users.
- Côté Edge: import XLSX statique + doublon de fonction provoquaient un échec de démarrage.
- Côté SQL: `run_algolia_data_task_override` utilisait `content` (ancienne signature) alors que `pg_net.http_post` expose `body` -> `column "content" does not exist`.

### Changements
- Edge Function `import-csv-user` (v15)
  - Suppression d’un doublon `formatError`.
  - Import `xlsx` passé en **chargement dynamique** (`await import(...)`) dans `readXlsxContent` pour éviter un boot fail si le module est indisponible au démarrage.
- SQL (Supabase)
  - `run_algolia_data_task_override`: migration appliquée pour récupérer `body` depuis `pg_net.http_post`, parser en JSON et journaliser `http` + `body`.
  - Fallback credentials Algolia via Vault conservé (`ALGOLIA_APP_ID` / `ALGOLIA_ADMIN_KEY`).
- Docs
  - CHANGELOG 2025-09-17.
  - Doc migration: `docs/migration/fix-run_algolia_override-2025-09-17.md`.

### Résultat
- Import utilisateur refonctionnel (fin des 503/502 liés au boot et à RunTask override).
- Délégation `chunked-upload` -> `import-csv-user` stable.

### Tests
- Import d’un dataset user: OK (staging -> projection -> RunTask -> finalize -> favoris auto si coché).

### Suivi/Notes
- La projection respecte le champ `Source` tel que fourni (trigger de forçage supprimé précédemment).
- Les favoris auto utilisent `add_import_overlays_to_favorites` avec retries.

