### PR TITLE
Search: suppression du tri/filtrage client; ranking 100% Algolia + fix Unité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - 2025-09-17: Ajout auto des favoris délégué à finalize_user_import; suppression de la logique legacy dans import-csv-user; message d'import réussi simplifié; suppression des doublons de message et du taux de compression.
+- 2025-09-17: Recherche – suppression du tri et des filtrages côté client sur la page Search; l’ordre est désormais entièrement piloté par Algolia (ranking). UI « résultats par page » et tri supprimés, plage FE client supprimée. Rétablissement de `ruleContexts` pour l’origine uniquement.
 ## 2025-09-10
 
 - Import utilisateur stabilisé

--- a/src/components/search/algolia/AlgoliaSearchDashboard.tsx
+++ b/src/components/search/algolia/AlgoliaSearchDashboard.tsx
@@ -37,7 +37,7 @@ const AlgoliaSearchContent: React.FC = () => {
           {/* Results Section */}
           <section className="lg:col-span-3">
             <Configure 
-              hitsPerPage={36} 
+              hitsPerPage={36}
               ruleContexts={[`origin:${origin}`]}
             />
             <SearchStats />

--- a/src/components/search/favoris/FavorisSearchResults.tsx
+++ b/src/components/search/favoris/FavorisSearchResults.tsx
@@ -352,12 +352,7 @@ export const FavorisSearchResults: React.FC<FavorisSearchResultsProps> = ({
                             <span className="text-sm font-semibold text-foreground">Unité</span>
                             <PremiumBlur isBlurred={shouldBlur} showBadge={false}>
                               <p className="text-sm font-light">
-                                {(() => {
-                                  const attr = (hit as any).Unite_fr !== undefined
-                                    ? 'Unite_fr'
-                                    : ((hit as any).Unite_en !== undefined ? 'Unite_en' : "Unité donnée d'activité");
-                                  return <Highlight hit={hit as any} attribute={attr as any} />;
-                                })()}
+                                {(hit as any).Unite_fr || (hit as any).Unite_en || ''}
                               </p>
                             </PremiumBlur>
                           </div>

--- a/supabase/functions/algolia-search-proxy/index.ts
+++ b/supabase/functions/algolia-search-proxy/index.ts
@@ -346,25 +346,8 @@ Deno.serve(async (req) => {
       let combinedFacetFilters: any[] = [...appliedFacetFilters]
       if (facetFilters) { if (Array.isArray(facetFilters)) combinedFacetFilters = [...combinedFacetFilters, ...facetFilters]; else combinedFacetFilters.push(facetFilters) }
 
-      // Résoudre le tri depuis ruleContexts -> sélection d'un index (réplica) pour exhaustive sorting
-      const rc: string[] = Array.isArray(otherParams?.ruleContexts) ? otherParams.ruleContexts : []
-      let sortKey: string | null = null
-      for (const tag of rc) { if (typeof tag === 'string' && tag.startsWith('sort:')) { sortKey = tag.slice(5); break } }
-      // Mapping des réplicas attendus (à créer côté Algolia)
-      // ef_all (par défaut)
-      // ef_all__fe_asc, ef_all__fe_desc, ef_all__date_desc, ef_all__date_asc, ef_all__nom_asc, ef_all__nom_desc, ef_all__source_asc
-      const resolveIndexForSort = (key: string | null | undefined): string => {
-        switch (key) {
-          case 'fe_asc': return `${ALGOLIA_INDEX_ALL}__fe_asc`
-          case 'fe_desc': return `${ALGOLIA_INDEX_ALL}__fe_desc`
-          case 'date_desc': return `${ALGOLIA_INDEX_ALL}__date_desc`
-          case 'date_asc': return `${ALGOLIA_INDEX_ALL}__date_asc`
-          default: return ALGOLIA_INDEX_ALL
-        }
-      }
-      const targetIndexName = resolveIndexForSort(sortKey)
-      // DEBUG: vérifier le routage de tri
-      try { console.log('ALGOLIA_SORT_ROUTING', { sortKey, targetIndexName, ruleContexts: rc }); } catch {}
+      // Le tri côté client est supprimé. On utilise toujours l'index par défaut côté Algolia.
+      const targetIndexName = ALGOLIA_INDEX_ALL
 
       const paramsObjRaw: Record<string, any> = { query: query || '', filters: combinedFilters, facetFilters: combinedFacetFilters.length > 0 ? combinedFacetFilters : undefined, ...otherParams }
       const { _search_context: _ctxIgnored, origin: _originIgnored, workspace_id: _wsParamIgnored, ...paramsObj } = paramsObjRaw

--- a/supabase/functions/algolia-search-proxy/index.ts
+++ b/supabase/functions/algolia-search-proxy/index.ts
@@ -346,10 +346,30 @@ Deno.serve(async (req) => {
       let combinedFacetFilters: any[] = [...appliedFacetFilters]
       if (facetFilters) { if (Array.isArray(facetFilters)) combinedFacetFilters = [...combinedFacetFilters, ...facetFilters]; else combinedFacetFilters.push(facetFilters) }
 
+      // Résoudre le tri depuis ruleContexts -> sélection d'un index (réplica) pour exhaustive sorting
+      const rc: string[] = Array.isArray(otherParams?.ruleContexts) ? otherParams.ruleContexts : []
+      let sortKey: string | null = null
+      for (const tag of rc) { if (typeof tag === 'string' && tag.startsWith('sort:')) { sortKey = tag.slice(5); break } }
+      // Mapping des réplicas attendus (à créer côté Algolia)
+      // ef_all (par défaut)
+      // ef_all__fe_asc, ef_all__fe_desc, ef_all__date_desc, ef_all__date_asc, ef_all__nom_asc, ef_all__nom_desc, ef_all__source_asc
+      const resolveIndexForSort = (key: string | null | undefined): string => {
+        switch (key) {
+          case 'fe_asc': return `${ALGOLIA_INDEX_ALL}__fe_asc`
+          case 'fe_desc': return `${ALGOLIA_INDEX_ALL}__fe_desc`
+          case 'date_desc': return `${ALGOLIA_INDEX_ALL}__date_desc`
+          case 'date_asc': return `${ALGOLIA_INDEX_ALL}__date_asc`
+          default: return ALGOLIA_INDEX_ALL
+        }
+      }
+      const targetIndexName = resolveIndexForSort(sortKey)
+      // DEBUG: vérifier le routage de tri
+      try { console.log('ALGOLIA_SORT_ROUTING', { sortKey, targetIndexName, ruleContexts: rc }); } catch {}
+
       const paramsObjRaw: Record<string, any> = { query: query || '', filters: combinedFilters, facetFilters: combinedFacetFilters.length > 0 ? combinedFacetFilters : undefined, ...otherParams }
       const { _search_context: _ctxIgnored, origin: _originIgnored, workspace_id: _wsParamIgnored, ...paramsObj } = paramsObjRaw
-      const cacheKey = JSON.stringify({ requestWorkspaceId, searchType: effectiveType, params: paramsObj })
-      return { cacheKey, body: { indexName: ALGOLIA_INDEX_ALL, params: encodeParams(paramsObj) }, index: idx }
+      const cacheKey = JSON.stringify({ requestWorkspaceId, searchType: effectiveType, indexName: targetIndexName, params: paramsObj })
+      return { cacheKey, body: { indexName: targetIndexName, params: encodeParams(paramsObj) }, index: idx }
     })
 
     // Partitionner cache hits / misses


### PR DESCRIPTION
Mise à jour: suppression du routage par réplicas côté Edge Function.

- Retrait du code serveur lisant `ruleContexts` avec `sort:*` et de `resolveIndexForSort` (devenu inutile car le client ne propage plus de tri).
- L’index utilisé est toujours `ALGOLIA_INDEX_ALL`.
- Cohérent avec la PR: tri et filtrage client supprimés; ranking 100% Algolia.

Impact:
- Évite du code mort et tout risque de divergence avec des réplicas non alimentés.
- Simplifie la maintenance côté proxy.

Checklist inchangée.
