### PR TITLE
fix(sql): resolve is_supra_admin overload ambiguity on restore/upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2025-09-19
+
+- Supabase SQL
+  - Migration de garde-fou: suppression de l’overload `public.is_supra_admin()` sans argument et conservation de la version à 1 argument avec `DEFAULT auth.uid()` pour éviter l’ambiguïté lors des restore/upgrade Postgres (erreur "function public.is_supra_admin() is not unique"). Aucun impact sur les policies: les appels `is_supra_admin()` restent supportés via le paramètre par défaut.
+
 ## 2025-09-10
 
 - Import utilisateur stabilisé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
 ## 2025-09-17
 
+- Divers
+  - Ajout auto des favoris délégué à finalize_user_import; suppression de la logique legacy dans import-csv-user; message d'import réussi simplifié; suppression des doublons de message et du taux de compression.
+  - Recherche – suppression du tri et des filtrages côté client sur la page Search; l’ordre est désormais entièrement piloté par Algolia (ranking). UI « résultats par page » et tri supprimés, plage FE client supprimée. Rétablissement de `ruleContexts` pour l’origine uniquement.
+
 - Edge Functions
   - `import-csv-user` v15: correction BOOT_ERROR en supprimant un doublon de fonction et en chargeant `xlsx` dynamiquement via `await import(...)` (évite un échec de démarrage si le module n'est pas résolu au boot).
   - `chunked-upload`: délégation inchangée, mais renverra désormais l'erreur applicative de l'Edge import si présente.

--- a/supabase/migrations/20250919000000_fix_is_supra_admin_signature.sql
+++ b/supabase/migrations/20250919000000_fix_is_supra_admin_signature.sql
@@ -1,0 +1,20 @@
+-- Fix is_supra_admin signature to avoid overload ambiguity during restore/upgrade
+-- 1) Remove potential 0-argument overload if present
+DROP FUNCTION IF EXISTS public.is_supra_admin();
+
+-- 2) Ensure the 1-argument version exists with DEFAULT, used transparently by calls like is_supra_admin()
+CREATE OR REPLACE FUNCTION public.is_supra_admin(user_uuid uuid DEFAULT auth.uid())
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    WHERE ur.user_id = user_uuid
+      AND (ur.is_supra_admin = TRUE OR ur.role = 'supra_admin')
+  );
+$$;
+
+


### PR DESCRIPTION
This PR adds a guard migration to avoid pg_restore/upgrade errors due to duplicate function overloads for `public.is_supra_admin`.

What changed:
- Drop the 0-argument overload if present
- Keep the 1-argument version with `DEFAULT auth.uid()`
- Update CHANGELOG (2025-09-19)

Why:
- Prevents error during restore: `function public.is_supra_admin() is not unique`

Impact:
- RLS policies using `is_supra_admin()` remain working via default parameter
- No data impact
