### PR TITLE
fix: rétablir react-i18next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
-        "react-i18next": "^15.1.5",
+        "react-i18next": "^15.7.4",
         "react-instantsearch": "^7.16.2",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "i18next": "^23.11.5",
     "input-otp": "^1.2.4",
     "isomorphic-dompurify": "^2.13.0",
     "lucide-react": "^0.462.0",
@@ -60,6 +61,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-i18next": "^15.7.4",
     "react-instantsearch": "^7.16.2",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.3",
@@ -70,9 +72,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8",
-    "i18next": "^23.11.5",
-    "react-i18next": "^15.1.5"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
## Résumé
- réinstalle `react-i18next@^15.7.4` pour corriger l'erreur Vite `[plugin:vite:import-analysis] Failed to resolve import "react-i18next"`
- conserve `i18next@^23.11.5` côté application
- un flush du cache Vite a été réalisé localement (non commité) afin de repartir sur un graphe propre

## Tests
- `npm ls react-i18next i18next`
- `npm run dev` (démarrage sans 500 liés au module i18n)
